### PR TITLE
Implement get products batch endpoint

### DIFF
--- a/src/main/java/edu/api/products/application/controllers/ProductController.java
+++ b/src/main/java/edu/api/products/application/controllers/ProductController.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -39,10 +40,10 @@ public class ProductController {
         }
     }
 
-    @GetMapping("/{tenantId}/{productId}")
-    public ResponseEntity<Product> getProduct(@PathVariable UUID tenantId, @PathVariable UUID productId) {
+    @GetMapping("/product/{productId}")
+    public ResponseEntity<Product> getProduct(@PathVariable UUID productId) {
         try {
-            Product product = productService.get(tenantId, productId);
+            Product product = productService.getById(productId);
             return ResponseEntity.status(HttpStatus.OK).body(product);
         } catch (InvalidTenantException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
@@ -109,6 +110,21 @@ public class ProductController {
         try {
             productService.deleteAllByTenantId(tenantId);
             return ResponseEntity.noContent().build();
+        } catch (BusinessException e) {
+            return ResponseEntity.badRequest().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @PostMapping("/batch")
+    public ResponseEntity<List<ProductPreviewDTO>> getProductsBatch(@RequestBody List<UUID> productIds) {
+        try {
+            List<Product> products = productService.getProductsByIds(productIds);
+            List<ProductPreviewDTO> previews = products.stream()
+                    .map(ProductMapper::toPreview)
+                    .toList();
+            return ResponseEntity.ok(previews);
         } catch (BusinessException e) {
             return ResponseEntity.badRequest().build();
         } catch (RuntimeException e) {

--- a/src/main/java/edu/api/products/application/services/IProductService.java
+++ b/src/main/java/edu/api/products/application/services/IProductService.java
@@ -5,13 +5,15 @@ import edu.api.products.domain.Product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface IProductService {
     Product create(ProductDTO product);
-    Product get(UUID tenantId, UUID id);
+    Product getById(UUID id);
     Product update(UUID tenantId, UUID productId, ProductDTO product);
     void delete(UUID tenantId, UUID id);
     Page<Product> getProducts(UUID tenantId, Pageable pageable);
     void deleteAllByTenantId(UUID tenantId);
+    List<Product> getProductsByIds(List<UUID> productIds);
 }

--- a/src/main/java/edu/api/products/application/services/ProductService.java
+++ b/src/main/java/edu/api/products/application/services/ProductService.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -37,17 +38,15 @@ public class ProductService implements IProductService {
     }
 
     @Override
-    public Product get(UUID tenantId, UUID id) {
-        if (tenantId == null) {
-            throw new BusinessException("Tenant Id must not be null.");
+    public Product getById(UUID productId) {
+        if (productId == null) {
+            throw new BusinessException("Product ID must not be null.");
         }
 
-        if (id == null) {
-            throw new BusinessException("Product Id must not be null.");
-        }
-
-        return validateProductExistence(tenantId, id);
+        return productRepository.findById(productId)
+                .orElseThrow(() -> new ProductNotFoundException("Product not found."));
     }
+
 
     @Override
     public Product update(UUID tenantId, UUID productId, ProductDTO product) {
@@ -129,5 +128,14 @@ public class ProductService implements IProductService {
         }
 
         return existingProduct;
+    }
+
+    @Override
+    public List<Product> getProductsByIds(List<UUID> productIds) {
+        if (productIds == null || productIds.isEmpty()) {
+            throw new BusinessException("Product ID list must not be null or empty.");
+        }
+
+        return productRepository.findAllByIdIn(productIds);
     }
 }

--- a/src/main/java/edu/api/products/infrastructure/IProductRepository.java
+++ b/src/main/java/edu/api/products/infrastructure/IProductRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface IProductRepository extends JpaRepository<Product, UUID> {
     Page<Product> findAllByTenantId(UUID tenantId, Pageable pageable);
     void deleteByTenantId(UUID tenantId);
+    List<Product> findAllByIdIn(List<UUID> ids);
 }

--- a/src/test/java/edu/api/products/controllers/ProductControllerTest.java
+++ b/src/test/java/edu/api/products/controllers/ProductControllerTest.java
@@ -48,7 +48,9 @@ public class ProductControllerTest {
                 150.0,
                 List.of(Material.BIRCH_WOOD),
                 Style.MODERN,
-                tenantId
+                tenantId,
+                null,
+                ""
         );
         Product createdProduct = new Product(
                 UUID.randomUUID(),
@@ -57,7 +59,9 @@ public class ProductControllerTest {
                 productDTO.price(),
                 productDTO.materials(),
                 productDTO.style(),
-                productDTO.tenantId()
+                productDTO.tenantId(),
+                productDTO.gallery(),
+                productDTO.model()
         );
 
         when(productService.create(any(ProductDTO.class))).thenReturn(createdProduct);
@@ -76,7 +80,9 @@ public class ProductControllerTest {
                 -50.0,
                 List.of(Material.PINE_WOOD),
                 Style.MODERN,
-                tenantId
+                tenantId,
+                List.of(),
+                ""
         );
 
         doThrow(new BusinessException("Price out of range"))
@@ -96,7 +102,9 @@ public class ProductControllerTest {
                 150.0,
                 List.of(Material.BIRCH_WOOD),
                 Style.MODERN,
-                tenantId
+                tenantId,
+                List.of(),
+                ""
         );
 
         Product createdProduct = new Product(
@@ -106,7 +114,9 @@ public class ProductControllerTest {
                 productDTO.price(),
                 productDTO.materials(),
                 productDTO.style(),
-                productDTO.tenantId()
+                productDTO.tenantId(),
+                productDTO.gallery(),
+                productDTO.model()
         );
 
         when(productService.create(any(ProductDTO.class))).thenReturn(createdProduct);
@@ -121,9 +131,9 @@ public class ProductControllerTest {
         Product createdResponse = objectMapper.readValue(responseBody, Product.class);
         UUID productId = createdResponse.getId();
 
-        when(productService.get(any(UUID.class), any(UUID.class))).thenReturn(createdProduct);
+        when(productService.getById(any(UUID.class))).thenReturn(createdProduct);
 
-        mockMvc.perform(get("/products/" + tenantId + "/" + productId)
+        mockMvc.perform(get("/products/" + productId)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }
@@ -136,7 +146,9 @@ public class ProductControllerTest {
                 1350.0,
                 List.of(Material.BIRCH_WOOD),
                 Style.MODERN,
-                tenantId
+                tenantId,
+                List.of(),
+                ""
         );
 
         Product createdProduct = new Product(
@@ -146,7 +158,9 @@ public class ProductControllerTest {
                 productDTO.price(),
                 productDTO.materials(),
                 productDTO.style(),
-                productDTO.tenantId()
+                productDTO.tenantId(),
+                productDTO.gallery(),
+                productDTO.model()
         );
 
         when(productService.create(any(ProductDTO.class))).thenReturn(createdProduct);
@@ -167,7 +181,9 @@ public class ProductControllerTest {
                 1550.0,
                 List.of(Material.BIRCH_WOOD),
                 Style.MODERN,
-                tenantId
+                tenantId,
+                List.of(),
+                ""
         );
 
         when(productService.update(any(UUID.class), any(UUID.class), any(ProductDTO.class))).thenReturn(createdProduct);
@@ -217,7 +233,9 @@ public class ProductControllerTest {
                 350.0,
                 List.of(Material.PINE_WOOD),
                 Style.MODERN,
-                tenantId
+                tenantId,
+                List.of(),
+                ""
         );
 
         Product createdProduct = new Product(
@@ -227,7 +245,9 @@ public class ProductControllerTest {
                 productDTO.price(),
                 productDTO.materials(),
                 productDTO.style(),
-                productDTO.tenantId()
+                productDTO.tenantId(),
+                productDTO.gallery(),
+                productDTO.model()
         );
 
         when(productService.create(any(ProductDTO.class))).thenReturn(createdProduct);
@@ -242,9 +262,9 @@ public class ProductControllerTest {
         Product createdResponse = objectMapper.readValue(responseBody, Product.class);
         UUID productId = createdResponse.getId();
 
-        when(productService.get(tenantId, productId)).thenReturn(createdResponse);
+        when(productService.getById(productId)).thenReturn(createdResponse);
 
-        mockMvc.perform(delete("/products/" + tenantId + "/" + productId))
+        mockMvc.perform(delete("/products/" + productId))
                 .andExpect(status().isNoContent());
     }
 


### PR DESCRIPTION
This pull request adds a new endpoint to the Products API that allows clients to retrieve multiple products in a single request by providing a list of product IDs. This functionality is intended to support features such as the Favorites screen in the User App, improving performance by reducing the number of separate requests.

### Main Changes:

- Implemented POST /v1/products/batch endpoint.
- Added a request body handler that accepts a list of UUIDs.
- Added service method to fetch and return matching products.
- Included basic validation and error handling.

