### PR TITLE
Search and filter products endpoint

### DIFF
--- a/src/main/java/edu/api/products/application/controllers/ProductController.java
+++ b/src/main/java/edu/api/products/application/controllers/ProductController.java
@@ -2,13 +2,16 @@ package edu.api.products.application.controllers;
 
 import edu.api.products.application.dto.ProductDTO;
 import edu.api.products.application.dto.ProductPreviewDTO;
+import edu.api.products.application.dto.ProductSearchCriteria;
 import edu.api.products.application.dto.UpdateProductDTO;
 import edu.api.products.application.exceptions.BusinessException;
 import edu.api.products.application.exceptions.InvalidTenantException;
 import edu.api.products.application.exceptions.ProductNotFoundException;
 import edu.api.products.application.mappers.ProductMapper;
 import edu.api.products.application.services.ProductService;
+import edu.api.products.domain.Material;
 import edu.api.products.domain.Product;
+import edu.api.products.domain.Style;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -93,7 +96,7 @@ public class ProductController {
     public ResponseEntity<Page<ProductPreviewDTO>> getProducts(
             @PathVariable UUID tenantId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "20") int size
     ) {
         try {
             Pageable pageable = PageRequest.of(page, size);
@@ -153,4 +156,21 @@ public class ProductController {
         }
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<List<ProductPreviewDTO>> searchProducts(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) Style style,
+            @RequestParam(required = false) List<Material> materials,
+            @RequestParam(defaultValue = "name") String sortBy,
+            @RequestParam(defaultValue = "asc") String direction,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        ProductSearchCriteria criteria = new ProductSearchCriteria(name, style, materials, sortBy, direction, page, size);
+        Page<Product> results = productService.searchProducts(criteria);
+        List<ProductPreviewDTO> previews = results.getContent().stream()
+                .map(ProductMapper::toPreview)
+                .toList();
+        return ResponseEntity.ok(previews);
+    }
 }

--- a/src/main/java/edu/api/products/application/dto/ProductSearchCriteria.java
+++ b/src/main/java/edu/api/products/application/dto/ProductSearchCriteria.java
@@ -1,0 +1,16 @@
+package edu.api.products.application.dto;
+
+import edu.api.products.domain.Material;
+import edu.api.products.domain.Style;
+
+import java.util.List;
+
+public record ProductSearchCriteria(
+        String name,
+        Style style,
+        List<Material> materials,
+        String sortBy,
+        String direction,
+        int page,
+        int size
+) { }

--- a/src/main/java/edu/api/products/application/services/IProductService.java
+++ b/src/main/java/edu/api/products/application/services/IProductService.java
@@ -19,5 +19,5 @@ public interface IProductService {
     void deleteAllByTenantId(UUID tenantId);
     List<Product> getProductsByIds(List<UUID> productIds);
     Product partialUpdate(UUID tenantId, UUID productId, UpdateProductDTO dto);
-    Page<Product> searchProducts(ProductSearchCriteria criteria);
+    Page<Product> search(ProductSearchCriteria criteria, Pageable pageable);
 }

--- a/src/main/java/edu/api/products/application/services/IProductService.java
+++ b/src/main/java/edu/api/products/application/services/IProductService.java
@@ -1,6 +1,7 @@
 package edu.api.products.application.services;
 
 import edu.api.products.application.dto.ProductDTO;
+import edu.api.products.application.dto.ProductSearchCriteria;
 import edu.api.products.application.dto.UpdateProductDTO;
 import edu.api.products.domain.Product;
 import org.springframework.data.domain.Page;
@@ -18,4 +19,5 @@ public interface IProductService {
     void deleteAllByTenantId(UUID tenantId);
     List<Product> getProductsByIds(List<UUID> productIds);
     Product partialUpdate(UUID tenantId, UUID productId, UpdateProductDTO dto);
+    Page<Product> searchProducts(ProductSearchCriteria criteria);
 }

--- a/src/main/java/edu/api/products/application/services/ProductService.java
+++ b/src/main/java/edu/api/products/application/services/ProductService.java
@@ -163,19 +163,11 @@ public class ProductService implements IProductService {
     }
 
     @Override
-    public Page<Product> searchProducts(ProductSearchCriteria criteria) {
-        Sort sort = Sort.by(
-                "desc".equalsIgnoreCase(criteria.direction()) ? Sort.Direction.DESC : Sort.Direction.ASC,
-                Optional.ofNullable(criteria.sortBy()).orElse("name")
-        );
-
-        Pageable pageable = PageRequest.of(criteria.page(), criteria.size(), sort);
-
-        return productRepositoryCustom.search(
-                criteria.name(),
-                criteria.style(),
-                criteria.materials(),
-                pageable
-        );
+    public Page<Product> search(ProductSearchCriteria criteria, Pageable pageable) {
+        if (criteria == null) {
+            throw new BusinessException("Search criteria must not be null.");
+        }
+        return productRepositoryCustom.search(criteria, pageable);
     }
+
 }

--- a/src/main/java/edu/api/products/infrastructure/IProductRepositoryCustom.java
+++ b/src/main/java/edu/api/products/infrastructure/IProductRepositoryCustom.java
@@ -1,0 +1,13 @@
+package edu.api.products.infrastructure;
+
+import edu.api.products.domain.Material;
+import edu.api.products.domain.Product;
+import edu.api.products.domain.Style;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface IProductRepositoryCustom {
+    Page<Product> search(String name, Style style, List<Material> materials, Pageable pageable);
+}

--- a/src/main/java/edu/api/products/infrastructure/IProductRepositoryCustom.java
+++ b/src/main/java/edu/api/products/infrastructure/IProductRepositoryCustom.java
@@ -1,13 +1,10 @@
 package edu.api.products.infrastructure;
 
-import edu.api.products.domain.Material;
+import edu.api.products.application.dto.ProductSearchCriteria;
 import edu.api.products.domain.Product;
-import edu.api.products.domain.Style;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-
 public interface IProductRepositoryCustom {
-    Page<Product> search(String name, Style style, List<Material> materials, Pageable pageable);
+    Page<Product> search(ProductSearchCriteria productSearchCriteria, Pageable pageable);
 }

--- a/src/main/java/edu/api/products/infrastructure/ProductRepositoryImpl.java
+++ b/src/main/java/edu/api/products/infrastructure/ProductRepositoryImpl.java
@@ -1,0 +1,81 @@
+package edu.api.products.infrastructure;
+
+import edu.api.products.domain.Material;
+import edu.api.products.domain.Product;
+import edu.api.products.domain.Style;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class ProductRepositoryImpl implements IProductRepositoryCustom {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Page<Product> search(String name, Style style, List<Material> materials, Pageable pageable) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Product> query = cb.createQuery(Product.class);
+        Root<Product> root = query.from(Product.class);
+
+        List<Predicate> predicates = buildPredicates(cb, root, name, style, materials);
+
+        query.where(cb.and(predicates.toArray(new Predicate[0])));
+        query.select(root).distinct(true);
+
+        TypedQuery<Product> typedQuery = entityManager.createQuery(query);
+        typedQuery.setFirstResult((int) pageable.getOffset());
+        typedQuery.setMaxResults(pageable.getPageSize());
+
+        long count = countQuery(name, style, materials);
+
+        return new PageImpl<>(typedQuery.getResultList(), pageable, count);
+    }
+
+    private long countQuery(String name, Style style, List<Material> materials) {
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        Root<Product> root = countQuery.from(Product.class);
+
+        List<Predicate> predicates = buildPredicates(cb, root, name, style, materials);
+
+        countQuery.select(cb.countDistinct(root)).where(cb.and(predicates.toArray(new Predicate[0])));
+        return entityManager.createQuery(countQuery).getSingleResult();
+    }
+
+    private List<Predicate> buildPredicates(
+            CriteriaBuilder cb,
+            Root<Product> root,
+            String name,
+            Style style,
+            List<Material> materials
+    ) {
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (name != null && !name.isBlank()) {
+            predicates.add(cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%"));
+        }
+
+        if (style != null) {
+            predicates.add(cb.equal(root.get("style"), style));
+        }
+
+        if (materials != null && !materials.isEmpty()) {
+            predicates.add(root.join("materials").in(materials));
+        }
+
+        return predicates;
+    }
+}


### PR DESCRIPTION
This pull request adds a new route to the Products API. Clients can now search and filter products by name, materials or style using the unified /products/search endpoint and ordering alphabetically or by price.

### Main Changes:

- Implemented POST /products/search in the Products API.
- Handled response mapping and error forwarding.