### PR TITLE
Get general metrics summary

### DIFF
--- a/src/main/java/edu/api/products/application/controllers/ProductMetricController.java
+++ b/src/main/java/edu/api/products/application/controllers/ProductMetricController.java
@@ -1,5 +1,6 @@
 package edu.api.products.application.controllers;
 
+import edu.api.products.application.dto.GeneralMetricsReport;
 import edu.api.products.application.exceptions.BusinessException;
 import edu.api.products.application.exceptions.ProductNotFoundException;
 import edu.api.products.application.services.metrics.ProductMetricService;
@@ -18,7 +19,7 @@ public class ProductMetricController {
 
     private final ProductMetricService productMetricService;
 
-    @GetMapping("/metrics/{productId}")
+    @GetMapping("/{productId}")
     public ResponseEntity<ProductMetric> getProductMetric(@PathVariable UUID productId) {
         try {
             ProductMetric metric = productMetricService.getProductMetric(productId);
@@ -32,7 +33,7 @@ public class ProductMetricController {
         }
     }
 
-    @PostMapping("/metrics/click/{productId}")
+    @PostMapping("/click/{productId}")
     public ResponseEntity<Void> registerClick(@PathVariable UUID productId) {
         try {
             productMetricService.incrementClickMetric(productId);
@@ -46,7 +47,7 @@ public class ProductMetricController {
         }
     }
 
-    @PostMapping("/metrics/ar-views/{productId}")
+    @PostMapping("/ar-views/{productId}")
     public ResponseEntity<Void> registerArView(@PathVariable UUID productId) {
         try {
             productMetricService.incrementArViewMetric(productId);
@@ -60,7 +61,7 @@ public class ProductMetricController {
         }
     }
 
-    @PostMapping("/metrics/search-appearances/{productId}")
+    @PostMapping("/search-appearances/{productId}")
     public ResponseEntity<Void> registerSearchAppearances(@PathVariable UUID productId) {
         try {
             productMetricService.incrementSearchAppearMetric(productId);
@@ -70,6 +71,20 @@ public class ProductMetricController {
         }catch (BusinessException e) {
             return ResponseEntity.badRequest().build();
         } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/report/{tenantId}")
+    public ResponseEntity<GeneralMetricsReport> getTenantReport(@PathVariable UUID tenantId) {
+        try {
+            GeneralMetricsReport report = productMetricService.getTenantMetricsReport(tenantId);
+            return ResponseEntity.ok(report);
+        } catch (ProductNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        } catch (BusinessException e) {
+            return ResponseEntity.badRequest().build();
+        } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/src/main/java/edu/api/products/application/dto/GeneralMetricsReport.java
+++ b/src/main/java/edu/api/products/application/dto/GeneralMetricsReport.java
@@ -1,0 +1,31 @@
+package edu.api.products.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.YearMonth;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GeneralMetricsReport {
+
+    private UUID tenantId;
+    private YearMonth period;
+
+    private int totalClicks;
+    private int totalArViews;
+    private int totalSearchAppearances;
+    private int totalProducts;
+
+    private List<ProductMetricSummary> mostClickedProducts;
+    private List<ProductMetricSummary> mostViewedInAr;
+    private List<ProductMetricSummary> mostSearchedProducts;
+
+    private List<MonthlyGeneralMetric> monthlyMetrics;
+}

--- a/src/main/java/edu/api/products/application/dto/MonthlyGeneralMetric.java
+++ b/src/main/java/edu/api/products/application/dto/MonthlyGeneralMetric.java
@@ -1,0 +1,20 @@
+package edu.api.products.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.YearMonth;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MonthlyGeneralMetric {
+    private YearMonth month;
+    private int totalClicks;
+    private int totalArViews;
+    private int totalSearchAppearances;
+}
+

--- a/src/main/java/edu/api/products/application/dto/ProductMetricSummary.java
+++ b/src/main/java/edu/api/products/application/dto/ProductMetricSummary.java
@@ -1,0 +1,20 @@
+package edu.api.products.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductMetricSummary {
+    private UUID productId;
+    private String name;
+    private int clicks;
+    private int arViews;
+    private int searchAppearances;
+}

--- a/src/main/java/edu/api/products/infrastructure/metrics/IProductMetricRepository.java
+++ b/src/main/java/edu/api/products/infrastructure/metrics/IProductMetricRepository.java
@@ -1,11 +1,66 @@
 package edu.api.products.infrastructure.metrics;
 
+import edu.api.products.application.dto.ProductMetricSummary;
 import edu.api.products.domain.ProductMetric;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface IProductMetricRepository extends JpaRepository<ProductMetric, UUID> {
     Optional<ProductMetric> findByProductId(UUID productId);
+    @Query("""
+        SELECT new edu.api.products.application.dto.ProductMetricSummary(
+            p.id, p.name,
+            COALESCE(m.clicks, 0),
+            COALESCE(m.arViews, 0),
+            COALESCE(m.searchAppearances, 0)
+        )
+        FROM ProductMetric m
+        JOIN Product p ON m.productId = p.id
+        WHERE p.tenantId = :tenantId
+        ORDER BY m.clicks DESC
+    """)
+    List<ProductMetricSummary> findMostClickedProductsByTenant(@Param("tenantId") UUID tenantId, Pageable pageable);
+
+    @Query("""
+        SELECT new edu.api.products.application.dto.ProductMetricSummary(
+            p.id, p.name,
+            COALESCE(m.clicks, 0),
+            COALESCE(m.arViews, 0),
+            COALESCE(m.searchAppearances, 0)
+        )
+        FROM ProductMetric m
+        JOIN Product p ON m.productId = p.id
+        WHERE p.tenantId = :tenantId
+        ORDER BY m.arViews DESC
+    """)
+    List<ProductMetricSummary> findMostViewedInArByTenant(@Param("tenantId") UUID tenantId, Pageable pageable);
+
+    @Query("""
+        SELECT new edu.api.products.application.dto.ProductMetricSummary(
+            p.id, p.name,
+            COALESCE(m.clicks, 0),
+            COALESCE(m.arViews, 0),
+            COALESCE(m.searchAppearances, 0)
+        )
+        FROM ProductMetric m
+        JOIN Product p ON m.productId = p.id
+        WHERE p.tenantId = :tenantId
+        ORDER BY m.searchAppearances DESC
+    """)
+    List<ProductMetricSummary> findMostSearchedByTenant(@Param("tenantId") UUID tenantId, Pageable pageable);
+
+    @Query("""
+        SELECT SUM(m.clicks), SUM(m.arViews), SUM(m.searchAppearances)
+        FROM ProductMetric m
+        JOIN Product p ON m.productId = p.id
+        WHERE p.tenantId = :tenantId
+    """)
+    Object[] getTotalAggregatesByTenant(@Param("tenantId") UUID tenantId);
+
 }

--- a/src/main/java/edu/api/products/infrastructure/product/IProductRepository.java
+++ b/src/main/java/edu/api/products/infrastructure/product/IProductRepository.java
@@ -17,4 +17,5 @@ public interface IProductRepository extends JpaRepository<Product, UUID> {
     Page<Product> findAllByTenantIdAndDeletedFalse(UUID tenantId, Pageable pageable);
     Optional<Product> findByIdAndDeletedFalse(UUID productId);
     List<Product> findAllByIdInAndDeletedFalse(List<UUID> ids);
+    int countByTenantIdAndDeletedFalse(UUID tenantId);
 }


### PR DESCRIPTION
This pull request introduces a new endpoint in the Products Service to return a general summary of metrics per tenant. The response includes overall totals, per-product summaries, and monthly breakdowns using three structured DTOs.

### Main Changes:

- Created DTOs:
  - GeneralMetricsReportDTO: totalClicks, totalArViews, totalSearchAppearances
  - MonthlyGeneralMetricsDTO: List of metrics grouped by month
  - ProductMetricSummaryDTO: metrics per product
- Implemented aggregation logic to compute totals and group by tenant/month.
- Added GET /v1/metrics/summary/{tenantId} endpoint to expose the report.